### PR TITLE
Update app-misc/beersmith/beersmith-2.1.02.ebuild

### DIFF
--- a/app-misc/beersmith/beersmith-2.1.02.ebuild
+++ b/app-misc/beersmith/beersmith-2.1.02.ebuild
@@ -1,57 +1,51 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2013 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=4
+EAPI=5
 WX_GTK_VER="2.9"
 
-inherit eutils wxwidgets
+inherit eutils unpacker wxwidgets
 
-MY_PN="BeerSmith2"
+MY_PN="BeerSmith"
 
 DESCRIPTION="BeerSmith Home Brewing Software"
 HOMEPAGE="http://www.beersmith.com/"
-SRC_URI="x86? ( https://s3.amazonaws.com/BeerSmith2-1/BeerSmith-${PV}.deb )
-	amd64? ( https://s3.amazonaws.com/BeerSmith2-1/BeerSmith-${PV}_amd64.deb )"
+SRC_URI="x86? ( https://s3.amazonaws.com/${MY_PN}2-1/${MY_PN}-${PV}.deb )
+  amd64? ( https://s3.amazonaws.com/${MY_PN}2-1/${MY_PN}-${PV}_amd64.deb )"
 
-LICENSE="BeerSmith
+LICENSE="${MY_PN}
 	GPL-2"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="-* ~amd64 ~x86"
 IUSE=""
 
 RESTRICT="mirror"
 
 DEPEND=""
 RDEPEND="media-libs/libpng:1.2
-	x11-libs/libX11
 	sys-libs/zlib
 	x11-libs/cairo
 	x11-libs/gdk-pixbuf
-	x11-libs/libSM
-	x11-libs/pango
 	x11-libs/gtk+:2
+	x11-libs/libSM
+	x11-libs/libX11
+	x11-libs/pango
 	=x11-libs/wxGTK-2.9.3*[X]"
 
 S="${WORKDIR}"
-
-src_unpack() {
-	unpack ${A} ./data.tar.gz
-}
 
 src_install() {
 	into /opt
 	dobin usr/bin/beersmith2
 
-	insinto /usr/share/${MY_PN}
-	cd usr/share/${MY_PN}
-	doins -r *.bsmx *.xml *.bsopt Reports Updates help
+	insinto /usr/share/${MY_PN}2
+	doins -r usr/share/${MY_PN}2/{*.bsmx,*.xml,*.bsopt,Reports,Updates,help}
 
-	insinto /usr/share/${MY_PN}/icons
-	doins icons/*.png icons/*.gif
+	insinto /usr/share/${MY_PN}2/icons
+	doins usr/share/${MY_PN}2/icons/*.{gif,png}
 
-	cd "${S}"
 	sed -i 's#/usr/bin/##' usr/share/applications/beersmith2.desktop
 	domenu usr/share/applications/beersmith2.desktop
 	for size in 16 24 32 48 64 128 ; do


### PR DESCRIPTION
1. Replaced header version using `s/2012/2013/`.
2. Switched to EAPI 5 which has became stable.
3. Reuse of `MY_PN` by changing `BeerSmith2` to `BeerSmith`.
4. Added `unpacker` eclass, removed `src_unpack`.
5. Added `-*` to keywords, optional though...
6. Sorted dependencies.
7. Changed src_install to not require `cd`, use bash expansion.
